### PR TITLE
Rename methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,30 +18,33 @@ And then execute:
 
 ## Helpers usage
 
-### amp_image_tag(source, options = {})
+### image_tag(source, options = {})
+
+image_tag method creates a `<amp-img>` tag if it's passed `amp` option as true.  
+Learn more about [amp-img tag](https://ampbyexample.com/components/amp-img/)
 
 #### String Source
 
-      $ amp_image_tag('http://placehold.it/350x150', width: 20, height: 20)
+      $ image_tag('http://placehold.it/350x150', width: 20, height: 20, amp: true)
       #=> '<amp-img alt="350x150" height="20" src="http://placehold.it/350x150" width="20" /></amp-img>'
 
-      $ amp_image_tag('http://placehold.it/350x150', size: '20x20')
+      $ image_tag('http://placehold.it/350x150', size: '20x20', amp: true)
       #=> '<amp-img alt="350x150" height="20" src="http://placehold.it/350x150" width="20" /></amp-img>'
 
-      $ amp_image_tag('http://placehold.it/350x150')
+      $ image_tag('http://placehold.it/350x150', amp: true)
       #=> '<amp-img alt="350x150" height="150" src="http://placehold.it/350x150" width="350" /></amp-img>'
 
 #### Carrierwave Source
 
-      $ amp_image_tag(ThumbUploader.new.square)
+      $ image_tag(ThumbUploader.new.square, amp: true)
       #=> '<amp-img alt="Square 350x150" height="20" src="http://placehold.it/square_350x150" width="20" /></amp-img>'
 
 #### Retina
 
-      $ amp_image_tag('http://placehold.it/350x150', srcset: 'http://placehold.it/700x300 2x', size: '20x20')
+      $ image_tag('http://placehold.it/350x150', srcset: 'http://placehold.it/700x300 2x', size: '20x20', amp: true)
       #=> '<amp-img alt="350x150" height="20" src="http://placehold.it/350x150" srcset="http://placehold.it/700x300 2x" width="20" /></amp-img>'
 
-      $ amp_image_tag(ThumbUploader.new.square, format_2x: '%s_2x')
+      $ image_tag(ThumbUploader.new.square, format_2x: '%s_2x', amp: true)
       #=> '<amp-img alt="Square 350x150" height="20" src="http://placehold.it/square_350x150" srcset="http://placehold.it/square_2x_350x150 2x" width="20" /></amp-img>'
 
 
@@ -60,6 +63,32 @@ And then execute:
       end
     end
 
+### link_to(name = nil, options = nil, html_options = nil, &block)
+
+link_to method creates a `<a>` tag links to AMP cache if it's passed `amp` option as true.  
+Learn more about [using AMP cache](https://ampbyexample.com/advanced/using_the_google_amp_cache/).
+
+#### If indexed AMP cache is found
+
+      $ link_to(@title, @path, amp: true)
+      #=> "<a data-vars-link-url=\"https://ampbyexample.com/components/amp-form/preview/\" href=\"https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/components/amp-form/preview/\">link title</a>"
+
+      $ link_to(@path, amp: true) { @title }
+      #=> "<a data-vars-link-url=\"https://ampbyexample.com/components/amp-form/preview/\" href=\"https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/components/amp-form/preview/\">link title</a>"
+
+
+#### If indexed AMP cache is **NOT** found
+
+      $ link_to(@title, @path, amp: true)
+      #=> "<a data-vars-link-url=\"https://ampbyexample.com/components/amp-form/preview/noamp\" href=\"https://ampbyexample.com/components/amp-form/preview/noamp\">link title</a>"
+
+## amp-analytics conbination
+
+As you can see, AmpHelper puts the `data-vars-link-url` option on `<a>` tags.
+It's gonna help to tracking count of link clicking.
+
+Learn more about [Variables as data attribute](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute) for amp-analytics.
+
 ## Configure
 
 ### Configure ratina version name format For CarrierWave::Uploader
@@ -67,8 +96,17 @@ And then execute:
 config/initializers/amp_helper.rb
 
     AmpHelper.configure do |config|
+      # Enable amp image.
+      # Default: true
+      # config.enable_amp_image = true
+      #
       # Configure ratina version name format For CarrierWave::Uploader
+      # Default: nil
       # config.format_2x = '%s_2x'
+
+      # Enable amp cache link.
+      # Default: true
+      # config.enable_amp_link = Rails.env.production?
     end
 
 ## Development
@@ -83,4 +121,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To know AmpHelper ability, just look Usage section.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'amp_helper'
+gem 'amp_helper', '~> 1.0.0.pre'
 ```
 
 And then execute:

--- a/lib/amp_helper/amp_image_tag_helper.rb
+++ b/lib/amp_helper/amp_image_tag_helper.rb
@@ -3,12 +3,12 @@ module AmpImageTagHelper
     has_dimensions = (opts[:width] && opts[:height]) || opts[:size]
     set_dimensions(source, opts) if !has_dimensions
     set_scrset(source, opts)
-    image_tag_to_amp(image_tag(source, opts))
+    img_to_amp_img(original_image_tag(source, opts))
   end
 
   private
 
-  def image_tag_to_amp(img_tag)
+  def img_to_amp_img(img_tag)
     img_tag.gsub(/^<img/, '<amp-img').gsub(/>$/, '></amp-img>').html_safe
   end
 

--- a/lib/amp_helper/amp_image_tag_helper.rb
+++ b/lib/amp_helper/amp_image_tag_helper.rb
@@ -13,8 +13,7 @@ module AmpImageTagHelper
   end
 
   def set_dimensions(source, opts)
-    if source.kind_of?(CarrierWave::Uploader::Base) &&
-       !source.class.processors.empty?
+    if source.kind_of?(CarrierWave::Uploader::Base) && !source.class.processors.empty?
       opts[:width], opts[:height] = source.class.processors[0][1]
     else
       opts[:width], opts[:height] = FastImage.size(source.to_s)

--- a/lib/amp_helper/amp_image_tag_helper.rb
+++ b/lib/amp_helper/amp_image_tag_helper.rb
@@ -1,7 +1,15 @@
 module AmpImageTagHelper
+  def self.included(base)
+    base.module_eval do
+      alias_method :original_image_tag, :image_tag
+      alias_method :image_tag, :amp_image_tag
+    end
+  end
+
   def amp_image_tag(source, opts = {})
+    return original_image_tag(source, opts) unless opts.delete(:amp) && AmpHelper.configuration.enable_amp_image
     has_dimensions = (opts[:width] && opts[:height]) || opts[:size]
-    set_dimensions(source, opts) if !has_dimensions
+    set_dimensions(source, opts) unless has_dimensions
     set_scrset(source, opts)
     img_to_amp_img(original_image_tag(source, opts))
   end
@@ -13,7 +21,8 @@ module AmpImageTagHelper
   end
 
   def set_dimensions(source, opts)
-    if source.kind_of?(CarrierWave::Uploader::Base) && !source.class.processors.empty?
+    if source.kind_of?(CarrierWave::Uploader::Base) &&
+       !source.class.processors.empty?
       opts[:width], opts[:height] = source.class.processors[0][1]
     else
       opts[:width], opts[:height] = FastImage.size(source.to_s)

--- a/lib/amp_helper/amp_link_to_helper.rb
+++ b/lib/amp_helper/amp_link_to_helper.rb
@@ -9,7 +9,7 @@ module AmpLinkToHelper
   def amp_link_to(name = nil, options = nil, html_options = nil, &block)
     html_options, options, name = options, name, block if block_given?
     html_options ||= {}
-    set_amp_vars(options, html_options)
+    set_analytics_vars(options, html_options)
     options = cdn_url(options) if html_options.delete(:amp) && AmpHelper.configuration.enable_amp_link
     options, name, block = html_options, options, name if block_given?
     original_link_to(name, options, html_options, &block)
@@ -18,7 +18,7 @@ module AmpLinkToHelper
   private
 
   # Pass url to amp-analytics as 'linkUrl' variable.
-  def set_amp_vars(options, html_options)
+  def set_analytics_vars(options, html_options)
     html_options['data-vars-link-url'] = url_for(options)
   end
 

--- a/lib/amp_helper/amp_link_to_helper.rb
+++ b/lib/amp_helper/amp_link_to_helper.rb
@@ -1,11 +1,18 @@
 module AmpLinkToHelper
+  def self.included(base)
+    base.module_eval do
+      alias_method :original_link_to, :link_to
+      alias_method :link_to, :amp_link_to
+    end
+  end
+
   def amp_link_to(name = nil, options = nil, html_options = nil, &block)
     html_options, options, name = options, name, block if block_given?
     html_options ||= {}
     set_amp_vars(options, html_options)
-    options = cdn_url(options) if AmpHelper.configuration.amp_link
+    options = cdn_url(options) if html_options.delete(:amp) && AmpHelper.configuration.enable_amp_link
     options, name, block = html_options, options, name if block_given?
-    link_to(name, options, html_options, &block)
+    original_link_to(name, options, html_options, &block)
   end
 
   private

--- a/lib/amp_helper/configuration.rb
+++ b/lib/amp_helper/configuration.rb
@@ -9,11 +9,11 @@ module AmpHelper
   end
 
   class Configuration
-    attr_accessor :format_2x, :amp_link
+    attr_accessor :format_2x, :enable_amp_link
 
     def initialize
       @format_2x = nil
-      @amp_link = true
+      @enable_amp_link = true
     end
   end
 end

--- a/lib/amp_helper/configuration.rb
+++ b/lib/amp_helper/configuration.rb
@@ -9,9 +9,10 @@ module AmpHelper
   end
 
   class Configuration
-    attr_accessor :format_2x, :enable_amp_link
+    attr_accessor :enable_amp_image, :format_2x, :enable_amp_link
 
     def initialize
+      @enable_amp_image = true
       @format_2x = nil
       @enable_amp_link = true
     end

--- a/lib/amp_helper/generator.rb
+++ b/lib/amp_helper/generator.rb
@@ -5,6 +5,10 @@ module AmpHelper
       initializer 'amp_helper.rb' do
         <<-FILE.strip_heredoc
           AmpHelper.configure do |config|
+            # Enable amp image.
+            # Default: true
+            # config.enable_amp_image = true
+#
             # Configure ratina version name format For CarrierWave::Uploader
             # Default: nil
             # config.format_2x = '%s_2x'

--- a/lib/amp_helper/generator.rb
+++ b/lib/amp_helper/generator.rb
@@ -8,7 +8,7 @@ module AmpHelper
             # Enable amp image.
             # Default: true
             # config.enable_amp_image = true
-#
+
             # Configure ratina version name format For CarrierWave::Uploader
             # Default: nil
             # config.format_2x = '%s_2x'

--- a/lib/amp_helper/generator.rb
+++ b/lib/amp_helper/generator.rb
@@ -6,11 +6,12 @@ module AmpHelper
         <<-FILE.strip_heredoc
           AmpHelper.configure do |config|
             # Configure ratina version name format For CarrierWave::Uploader
+            # Default: nil
             # config.format_2x = '%s_2x'
 
             # Enable amp cache link.
-            # Recommend turning it on only while production mode.
-            config.amp_link = Rails.env.production?
+            # Default: true
+            # config.enable_amp_link = Rails.env.production?
           end
         FILE
       end

--- a/lib/amp_helper/version.rb
+++ b/lib/amp_helper/version.rb
@@ -1,3 +1,3 @@
 module AmpHelper
-  VERSION = '0.1.3'
+  VERSION = '1.0.0.pre.1'
 end

--- a/spec/amp_image_tag_helper_spec.rb
+++ b/spec/amp_image_tag_helper_spec.rb
@@ -1,58 +1,56 @@
 require 'spec_helper'
 
 describe AmpHelper do
-  it 'has a version number' do
-    expect(AmpHelper::VERSION).not_to be nil
-  end
-
   describe 'amp_image_tag' do
     before :all do
       @image_url = 'http://placehold.it/350x150'
       @uploader = ThumbUploader.new
       @view = ActionView::Base.new
-      @url_tag = '<amp-img alt="350x150" height="%d" src="http://placehold.it/'\
-                 '350x150" width="%d" /></amp-img>'
-      @uploader_tag = '<amp-img alt="Square 350x150" height="%d" src="http://p'\
-                      'lacehold.it/square_350x150" width="%'\
+      @url_tag = '<amp-img alt="350x150" height="%d" src="http://placehold.it/350x150" width="%d" /></amp-img>'
+      @uploader_tag = '<amp-img alt="Square 350x150" height="%d" src="http://placehold.it/square_350x150" width="%'\
                       'd" /></amp-img>'
-      @uploader_retina_tag = '<amp-img alt="Square 350x150" height="%d" src="h'\
-                             'ttp://placehold.it/square_350x150" srcset="http:'\
-                             '//placehold.it/square_2x_350x150 2x" width="%d" '\
-                             '/></amp-img>'
+      @uploader_retina_tag = '<amp-img alt="Square 350x150" height="%d" src="http://placehold.it/square_350x150" srcset="http://placehold.it/square_2x_350x150 2x" width="%d" /></amp-img>'
+      @original_tag = '<img alt="350x150" height="%d" src="http://placehold.it/350x150" width="%d" />'
     end
 
     it 'passed url with width and height returns amp-img tag' do
-      @view.amp_image_tag(@image_url, width: 20, height: 20).should(
+      @view.image_tag(@image_url, width: 20, height: 20, amp: true).should(
         eq(@url_tag % [20, 20].reverse)
       )
     end
 
+    it 'passed url with { amp: false } returns img tag' do
+      @view.image_tag(@image_url, width: 20, height: 20, amp: false).should(
+        eq(@original_tag % [20, 20].reverse)
+      )
+    end
+
     it 'passed url with size returns amp-img tag' do
-      @view.amp_image_tag(@image_url, size: '20x20').should(
+      @view.image_tag(@image_url, size: '20x20', amp: true).should(
         eq(@url_tag % [20, 20].reverse)
       )
     end
 
     it 'passed url returns amp-img tag' do
-      @view.amp_image_tag(@image_url).should(
+      @view.image_tag(@image_url, amp: true).should(
         eq(@url_tag % [350, 150].reverse)
       )
     end
 
     it 'passed uploader returns amp-img tag' do
-      @view.amp_image_tag(@uploader).should(
+      @view.image_tag(@uploader, amp: true).should(
         eq(@url_tag % [350, 150].reverse)
       )
     end
 
     it 'passed uploader with version returns amp-img tag' do
-      @view.amp_image_tag(@uploader.square).should(
+      @view.image_tag(@uploader.square, amp: true).should(
         eq(@uploader_tag % [20, 20].reverse)
       )
     end
 
     it 'passed uploader with version and format_2x returns amp-img tag' do
-      @view.amp_image_tag(@uploader.square, format_2x: '%s_2x').should(
+      @view.image_tag(@uploader.square, format_2x: '%s_2x', amp: true).should(
         eq(@uploader_retina_tag % [20, 20].reverse)
       )
     end
@@ -65,8 +63,19 @@ describe AmpHelper do
       end
 
       it 'passed uploader with version returns amp-img tag' do
-        @view.amp_image_tag(@uploader.square).should(
+        @view.image_tag(@uploader.square, amp: true).should(
           eq(@uploader_retina_tag % [20, 20].reverse)
+        )
+      end
+    end
+    describe 'with configuration.enable_amp_image = false' do
+      before :all do
+        AmpHelper.configuration.enable_amp_image = false
+      end
+
+      it 'passed url with width and height returns img tag' do
+        @view.image_tag(@image_url, width: 20, height: 20, amp: true).should(
+          eq(@original_tag % [20, 20].reverse)
         )
       end
     end

--- a/spec/amp_link_to_helper_spec.rb
+++ b/spec/amp_link_to_helper_spec.rb
@@ -9,53 +9,60 @@ describe AmpHelper do
     before :all do
       @view = ActionView::Base.new
       @view.request = Request.new('https', 'ampbyexample.com')
+
+      @title = 'link title'
+      @url = 'https://ampbyexample.com/components/amp-form/preview/'
+      @noamp_url = 'https://ampbyexample.com/components/amp-form/preview/noamp'
+      @cache_url = 'https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/components/amp-form/preview/'
     end
 
-    describe 'with config.amp_link = true' do
+    describe 'with configuration.enable_amp_link = true' do
       before :all do
-        AmpHelper.configuration.amp_link = true
+        AmpHelper.configuration.enable_amp_link = true
       end
 
       it 'returns a cache link' do
-        title = 'link title'
-        url = 'https://ampbyexample.com/components/amp-form/preview/'
-        cache_url = 'https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/components/amp-form/preview/'
-        @view.amp_link_to(title, url).should(
-          eq(a_tag(url, cache_url, title))
+        @view.link_to(@title, @url, amp: true).should(
+          eq(a_tag(@url, @cache_url, @title))
         )
       end
 
       it 'passed a page url don\'t have AMP returns an original link' do
-        title = 'link title'
-        url = 'https://ampbyexample.com/components/amp-form/preview/noamp'
-        @view.amp_link_to(title, url).should(
-          eq(a_tag(url, url, title))
+        @view.link_to(@title, @noamp_url, amp: true).should(
+          eq(a_tag(@noamp_url, @noamp_url, @title))
+        )
+      end
+
+      it 'passed { amp: false } returns an original link' do
+        @view.link_to(@title, @url, amp: false).should(
+          eq(a_tag(@url, @url, @title))
         )
       end
 
       describe 'given block' do
         it 'returns a cache link' do
-          title = 'link title'
-          url = 'https://ampbyexample.com/components/amp-form/preview/'
-          cache_url = 'https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/components/amp-form/preview/'
-          a_tag = @view.amp_link_to(url) { title }
+          a_tag = @view.link_to(@url, amp: true) { @title }
           a_tag.should(
-            eq(a_tag(url, cache_url, title))
+            eq(a_tag(@url, @cache_url, @title))
           )
         end
       end
     end
 
-    describe 'with config.amp_link = false' do
+    describe 'with configuration.enable_amp_link = false' do
       before :all do
-        AmpHelper.configuration.amp_link = false
+        AmpHelper.configuration.enable_amp_link = false
       end
 
       it 'returns an original link' do
-        title = 'link title'
-        url = 'https://ampbyexample.com/components/amp-form/preview'
-        @view.amp_link_to(title, url).should(
-          eq(a_tag(url, url, title))
+        @view.link_to(@title, @url, amp: true).should(
+          eq(a_tag(@url, @url, @title))
+        )
+      end
+
+      it 'passed { amp: true } returns an original link' do
+        @view.link_to(@title, @url, amp: true).should(
+          eq(a_tag(@url, @url, @title))
         )
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,9 +13,10 @@ ActionView::Base.send(:include, AmpLinkToHelper)
 
 AmpHelper.configure do |config|
   # Configure ratina version name format For CarrierWave::Uploader
+  # Default: nil
   # config.format_2x = '%s_2x'
 
   # Enable amp cache link.
-  # Recommend turning it on only while production mode.
-  config.amp_link = true
+  # Default: true
+  # config.enable_amp_link = Rails.env.production?
 end


### PR DESCRIPTION
- change version 0.1.3 to 1.0.0.pre.1
- change amp_image_tag method name to image_tag
- change amp_link_to method name to link_to
- some refactors